### PR TITLE
changed API: added a `config/0` callback for passing custom user parameters

### DIFF
--- a/include/emas.hrl
+++ b/include/emas.hrl
@@ -10,4 +10,5 @@
                      mutation_range :: float(),
                      mutation_chance :: float(),
                      recombination_chance :: float(),
-                     fight_number :: pos_integer()}).
+                     fight_number :: pos_integer(),
+                     extra :: term()}).

--- a/src/emas.erl
+++ b/src/emas.erl
@@ -30,7 +30,9 @@
 
 -spec start(pos_integer(), [tuple()]) -> agent().
 start(Time, ConfigOptions) ->
-    SimParams = emas_config:proplist_to_record(ConfigOptions),
+    SP = emas_config:proplist_to_record(ConfigOptions),
+    Env = SP#sim_params.genetic_ops,
+    SimParams = SP#sim_params{ extra = Env:config()},
     Config = mas_config:proplist_to_record([{agent_env, ?MODULE} |
                                             ConfigOptions]),
     io:format("### SimParams ~w~n", [SimParams]),

--- a/src/emas.erl
+++ b/src/emas.erl
@@ -32,7 +32,7 @@
 start(Time, ConfigOptions) ->
     SP = emas_config:proplist_to_record(ConfigOptions),
     Env = SP#sim_params.genetic_ops,
-    SimParams = SP#sim_params{ extra = Env:config()},
+    SimParams = SP#sim_params{extra = Env:config()},
     Config = mas_config:proplist_to_record([{agent_env, ?MODULE} |
                                             ConfigOptions]),
     io:format("### SimParams ~w~n", [SimParams]),

--- a/src/emas_genetic_ops.erl
+++ b/src/emas_genetic_ops.erl
@@ -19,3 +19,5 @@
 
 -callback recombination(solution(), solution(), sim_params()) ->
     {solution(), solution()}.
+
+-callback config() -> term().

--- a/src/emas_labs_ops.erl
+++ b/src/emas_labs_ops.erl
@@ -45,7 +45,7 @@ config() ->
 energy(Solution) ->
     L = length(Solution),
     Cs = [foldzip(drop(Solution, K), Solution)
-        || K <- lists:seq(1, L-1)],
+          || K <- lists:seq(1, L-1)],
     E = lists:foldl(fun (X, Acc) -> X*X + Acc end, 0, Cs),
     L*L*0.5/E.
 

--- a/src/emas_labs_ops.erl
+++ b/src/emas_labs_ops.erl
@@ -1,6 +1,6 @@
 -module (emas_labs_ops).
 -behaviour (emas_genetic_ops).
--export ([solution/1, evaluation/2, mutation/2, recombination/3]).
+-export ([solution/1, evaluation/2, mutation/2, recombination/3, config/0]).
 
 -include("emas.hrl").
 
@@ -19,29 +19,11 @@ solution(SP) ->
 evaluation(Solution, _SP) ->
     local_search(Solution).
 
--spec energy(solution()) -> float().
-energy(Solution) ->
-    L = length(Solution),
-    Cs = [foldzip(drop(Solution, K), Solution)
-          || K <- lists:seq(1, L-1)],
-    E = lists:foldl(fun (X, Acc) -> X*X + Acc end, 0, Cs),
-    L*L*0.5/E.
-
-
 -spec recombination(solution(), solution(), sim_params()) ->
                            {solution(), solution()}.
 recombination(S1, S2, _SP) ->
     Zipped = [recombination_features(F1, F2) || {F1, F2} <- lists:zip(S1, S2)],
     lists:unzip(Zipped).
-
-%% @doc Chooses a random order between the two initial features.
--spec recombination_features(float(), float()) -> {float(), float()}.
-recombination_features(F, F) -> {F, F};
-recombination_features(F1, F2) ->
-    case random:uniform() < 0.5 of
-        true -> {F1, F2};
-        false -> {F2, F1}
-    end.
 
 %% @doc Reproduction function for a single agent (mutation only).
 -spec mutation(solution(), sim_params()) -> solution().
@@ -53,7 +35,28 @@ mutation(Solution, SP) ->
                       end
               end, Solution).
 
+-spec config() -> term().
+config() ->
+    undefined.
+
 %% internal functions
+
+-spec energy(solution()) -> float().
+energy(Solution) ->
+    L = length(Solution),
+    Cs = [foldzip(drop(Solution, K), Solution)
+        || K <- lists:seq(1, L-1)],
+    E = lists:foldl(fun (X, Acc) -> X*X + Acc end, 0, Cs),
+    L*L*0.5/E.
+
+%% @doc Chooses a random order between the two initial features.
+-spec recombination_features(float(), float()) -> {float(), float()}.
+recombination_features(F, F) -> {F, F};
+recombination_features(F1, F2) ->
+    case random:uniform() < 0.5 of
+        true -> {F1, F2};
+        false -> {F2, F1}
+    end.
 
 drop([], _) -> [];
 drop(L, 0) -> L;

--- a/src/emas_test_ops.erl
+++ b/src/emas_test_ops.erl
@@ -2,7 +2,7 @@
 
 -behaviour(emas_genetic_ops).
 
--export ([evaluation/2, mutation/2, recombination/3, solution/1]).
+-export ([evaluation/2, mutation/2, recombination/3, solution/1, config/0]).
 
 -include("emas.hrl").
 
@@ -37,6 +37,10 @@ mutation(B, SP) ->
     Indexes = [random:uniform(length(S)) || _ <- lists:seq(1, NrGenesMutated)], % indices may be duplicated
     Mut = mutate_genes(S, lists:usort(Indexes), 1, [], SP), % usort removes duplicates
     erlang:term_to_binary(Mut).
+
+-spec config() -> term().
+config() ->
+    undefined.
 
 
 %% ====================================================================


### PR DESCRIPTION
In order to enable the user to pass to the operators his own properties, we added a new `extra` field in the `sim_params` record, which can accept values of any type (type `term()`).

Also added an empty `config/0` definition to `emas_test_ops` and `emas_labs_ops`